### PR TITLE
Pool based async persister

### DIFF
--- a/burr/core/parallelism.py
+++ b/burr/core/parallelism.py
@@ -19,10 +19,7 @@ from typing import (
 )
 
 from burr.common import async_utils
-from burr.common.async_utils import (
-    SyncOrAsyncGenerator,
-    SyncOrAsyncGeneratorOrItemOrList,
-)
+from burr.common.async_utils import SyncOrAsyncGenerator, SyncOrAsyncGeneratorOrItemOrList
 from burr.core import Action, ApplicationBuilder, ApplicationContext, Graph, State
 from burr.core.action import SingleStepAction
 from burr.core.application import ApplicationIdentifiers
@@ -58,27 +55,19 @@ class RunnableGraph:
         if isinstance(from_, RunnableGraph):
             return from_
         if isinstance(from_, Action):
-            assert from_.name is not None, (
-                "Action must have a name to be run, internal error, reach out to devs"
-            )
+            assert (
+                from_.name is not None
+            ), "Action must have a name to be run, internal error, reach out to devs"
         graph = GraphBuilder().with_actions(from_).build()
         (action,) = graph.actions
-        return RunnableGraph(
-            graph=graph, entrypoint=action.name, halt_after=[action.name]
-        )
+        return RunnableGraph(graph=graph, entrypoint=action.name, halt_after=[action.name])
 
 
 TrackerBehavior = Union[Literal["cascade"], None, TrackingClient]
-StatePersisterBehavior = Union[
-    Literal["cascade"], BaseStateSaver, LifecycleAdapter, None
-]
-StateInitializerBehavior = Union[
-    Literal["cascade"], BaseStateLoader, LifecycleAdapter, None
-]
+StatePersisterBehavior = Union[Literal["cascade"], BaseStateSaver, LifecycleAdapter, None]
+StateInitializerBehavior = Union[Literal["cascade"], BaseStateLoader, LifecycleAdapter, None]
 
-AdapterType = TypeVar(
-    "AdapterType", bound=Union[BaseStateSaver, BaseStateLoader, LifecycleAdapter]
-)
+AdapterType = TypeVar("AdapterType", bound=Union[BaseStateSaver, BaseStateLoader, LifecycleAdapter])
 
 
 @dataclasses.dataclass
@@ -97,9 +86,7 @@ class SubGraphTask:
     state_persister: Optional[BaseStateSaver] = None
     state_initializer: Optional[BaseStateLoader] = None
 
-    def _create_app_builder(
-        self, parent_context: ApplicationIdentifiers
-    ) -> ApplicationBuilder:
+    def _create_app_builder(self, parent_context: ApplicationIdentifiers) -> ApplicationBuilder:
         builder = (
             ApplicationBuilder()
             .with_graph(self.graph.graph)
@@ -115,9 +102,7 @@ class SubGraphTask:
             )
         )
         if self.tracker is not None:
-            builder = builder.with_tracker(
-                self.tracker
-            )  # TODO -- move this into the adapter
+            builder = builder.with_tracker(self.tracker)  # TODO -- move this into the adapter
 
         # In this case we want to persist the state for the app
         if self.state_persister is not None:
@@ -135,9 +120,7 @@ class SubGraphTask:
                 resume_at_next_action=True,
             )
         else:
-            builder = builder.with_entrypoint(self.graph.entrypoint).with_state(
-                self.state
-            )
+            builder = builder.with_entrypoint(self.graph.entrypoint).with_state(self.state)
 
         return builder
 
@@ -149,19 +132,15 @@ class SubGraphTask:
         app = self._create_app_builder(parent_context).build()
         action, result, state = app.run(
             halt_after=self.graph.halt_after,
-            inputs={
-                key: value
-                for key, value in self.inputs.items()
-                if not key.startswith("__")
-            },
+            inputs={key: value for key, value in self.inputs.items() if not key.startswith("__")},
         )
         return state
 
     async def arun(self, parent_context: ApplicationContext):
         # Here for backwards compatibility, not ideal
-        if (
-            self.state_initializer is not None and not self.state_initializer.is_async()
-        ) or (self.state_persister is not None and not self.state_persister.is_async()):
+        if (self.state_initializer is not None and not self.state_initializer.is_async()) or (
+            self.state_persister is not None and not self.state_persister.is_async()
+        ):
             logger.warning(
                 "You are using sync persisters for an async application which is not optimal. "
                 "Consider switching to an async persister implementation. We will make this an error soon."
@@ -171,11 +150,7 @@ class SubGraphTask:
             app = await self._create_app_builder(parent_context).abuild()
         action, result, state = await app.arun(
             halt_after=self.graph.halt_after,
-            inputs={
-                key: value
-                for key, value in self.inputs.items()
-                if not key.startswith("__")
-            },
+            inputs={key: value for key, value in self.inputs.items() if not key.startswith("__")},
         )
         return state
 
@@ -512,9 +487,7 @@ class MapActionsAndStates(TaskBasedParallelAction):
                 state_persister = state_initializer
             # In the case that they are not the same, we want to cascade the persister separately
             else:
-                state_persister = _cascade_adapter(
-                    self.state_persister(), context.state_persister
-                )
+                state_persister = _cascade_adapter(self.state_persister(), context.state_persister)
             return SubGraphTask(
                 graph=RunnableGraph.create(action),
                 inputs=inputs,
@@ -532,12 +505,8 @@ class MapActionsAndStates(TaskBasedParallelAction):
                     yield _create_task(key, action, substate)
 
         async def _atasks() -> AsyncGenerator[SubGraphTask, None]:
-            action_generator = async_utils.asyncify_generator(
-                self.actions(state, context, inputs)
-            )
-            state_generator = async_utils.asyncify_generator(
-                self.states(state, context, inputs)
-            )
+            action_generator = async_utils.asyncify_generator(self.actions(state, context, inputs))
+            state_generator = async_utils.asyncify_generator(self.states(state, context, inputs))
             actions = await async_utils.arealize(action_generator)
             states = await async_utils.arealize(state_generator)
             for i, action in enumerate(actions):
@@ -819,13 +788,10 @@ class PassThroughMapActionsAndStates(MapActionsAndStates):
             SubgraphType,
             List[SubgraphType],
             Callable[
-                [State, ApplicationContext, Dict[str, Any]],
-                SyncOrAsyncGenerator[SubgraphType],
+                [State, ApplicationContext, Dict[str, Any]], SyncOrAsyncGenerator[SubgraphType]
             ],
         ],
-        state: Callable[
-            [State, ApplicationContext, Dict[str, Any]], SyncOrAsyncGenerator[State]
-        ],
+        state: Callable[[State, ApplicationContext, Dict[str, Any]], SyncOrAsyncGenerator[State]],
         reducer: Callable[[State, SyncOrAsyncGenerator[State]], State],
         reads: List[str],
         writes: List[str],
@@ -899,8 +865,7 @@ def map_reduce_action(
         ],
     ],
     state: Callable[
-        [State, ApplicationContext, Dict[str, Any]],
-        SyncOrAsyncGeneratorOrItemOrList[State],
+        [State, ApplicationContext, Dict[str, Any]], SyncOrAsyncGeneratorOrItemOrList[State]
     ],
     reducer: Callable[[State, SyncOrAsyncGenerator[State]], State],
     reads: List[str],
@@ -909,10 +874,5 @@ def map_reduce_action(
 ):
     """Experimental API for creating a map-reduce action easily. We'll be improving this."""
     return PassThroughMapActionsAndStates(
-        action=action,
-        state=state,
-        reducer=reducer,
-        reads=reads,
-        writes=writes,
-        inputs=inputs,
+        action=action, state=state, reducer=reducer, reads=reads, writes=writes, inputs=inputs
     )

--- a/burr/integrations/persisters/b_asyncpg.py
+++ b/burr/integrations/persisters/b_asyncpg.py
@@ -25,6 +25,11 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister, BaseCopyable
         We suggest to use the persister either as a context manager through the ``async with`` clause or
         using the method ``.cleanup()``.
 
+    .. warning::
+        If you intend to use parallelism features or need to share this persister across multiple tasks,
+        you should initialize it with a connection pool (set ``use_pool=True`` in ``from_values``).
+        Direct connections cannot be shared across different tasks and may cause errors in concurrent scenarios.
+
     .. note::
         The implementation relies on the popular asyncpg library: https://github.com/MagicStack/asyncpg
 

--- a/burr/integrations/persisters/b_asyncpg.py
+++ b/burr/integrations/persisters/b_asyncpg.py
@@ -1,16 +1,22 @@
-from burr.integrations import base
+import json
+import logging
+from typing import Literal, Optional, ClassVar
+from typing import Any
 from burr.common.types import BaseCopyable
+from burr.core import persistence, state
+from burr.integrations import base
+
 
 try:
     import asyncpg
 except ImportError as e:
     base.require_plugin(e, "asyncpg")
 
-import json
-import logging
-from typing import Literal, Optional, ClassVar
+try:
+    from typing import Self
+except ImportError:
+    Self = Any
 
-from burr.core import persistence, state
 
 logger = logging.getLogger(__name__)
 
@@ -41,10 +47,10 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister, BaseCopyable
 
     .. code:: bash
 
-        docker run --name local-psql \\  # container name
-                   -v local_psql_data:/SOME/FILE_PATH/ \\  # mounting a volume for data persistence
-                   -p 54320:5432 \\  # port mapping
-                   -e POSTGRES_PASSWORD=my_password \\  # superuser password
+        docker run --name local-psql \\\\  # container name
+                   -v local_psql_data:/SOME/FILE_PATH/ \\\\  # mounting a volume for data persistence
+                   -p 54320:5432 \\\\  # port mapping
+                   -e POSTGRES_PASSWORD=my_password \\\\  # superuser password
                    -d postgres  # database name
 
     Then you should be able to create the class like this:

--- a/burr/integrations/persisters/b_asyncpg.py
+++ b/burr/integrations/persisters/b_asyncpg.py
@@ -1,4 +1,5 @@
 from burr.integrations import base
+from burr.common.types import BaseCopyable
 
 try:
     import asyncpg
@@ -7,14 +8,14 @@ except ImportError as e:
 
 import json
 import logging
-from typing import Literal, Optional
+from typing import Literal, Optional, ClassVar
 
 from burr.core import persistence, state
 
 logger = logging.getLogger(__name__)
 
 
-class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
+class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister, BaseCopyable):
     """Class for async PostgreSQL persistence of state.
 
     .. warning::
@@ -35,10 +36,10 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
 
     .. code:: bash
 
-        docker run --name local-psql \  # container name
-                   -v local_psql_data:/SOME/FILE_PATH/ \  # mounting a volume for data persistence
-                   -p 54320:5432 \  # port mapping
-                   -e POSTGRES_PASSWORD=my_password \  # superuser password
+        docker run --name local-psql \\  # container name
+                   -v local_psql_data:/SOME/FILE_PATH/ \\  # mounting a volume for data persistence
+                   -p 54320:5432 \\  # port mapping
+                   -e POSTGRES_PASSWORD=my_password \\  # superuser password
                    -d postgres  # database name
 
     Then you should be able to create the class like this:
@@ -48,10 +49,34 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
         p = await AsyncPostgreSQLPersister.from_values("postgres", "postgres", "my_password",
                                            "localhost", 54320, table_name="burr_state")
 
-
     """
 
     PARTITION_KEY_DEFAULT = ""
+
+    # Class variable to hold the connection pool
+    _pool: ClassVar[Optional[asyncpg.Pool]] = None
+
+    @classmethod
+    async def create_pool(
+        cls,
+        user: str,
+        password: str,
+        database: str,
+        host: str,
+        port: int,
+        **pool_kwargs,
+    ) -> asyncpg.Pool:
+        """Creates a connection pool that can be shared across persisters."""
+        if cls._pool is None:
+            cls._pool = await asyncpg.create_pool(
+                user=user,
+                password=password,
+                database=database,
+                host=host,
+                port=port,
+                **pool_kwargs,
+            )
+        return cls._pool
 
     @classmethod
     async def from_config(cls, config: dict) -> "AsyncPostgreSQLPersister":
@@ -67,6 +92,8 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
         host: str,
         port: int,
         table_name: str = "burr_state",
+        use_pool: bool = False,
+        **pool_kwargs,
     ) -> "AsyncPostgreSQLPersister":
         """Builds a new instance of the PostgreSQLPersister from the provided values.
 
@@ -76,29 +103,89 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
         :param host: the host of the PostgreSQL database.
         :param port: the port of the PostgreSQL database.
         :param table_name:  the table name to store things under.
+        :param use_pool: whether to use a connection pool (True) or a direct connection (False)
+        :param pool_kwargs: additional kwargs to pass to the pool creation
         """
-        connection = await asyncpg.connect(
-            user=user, password=password, database=db_name, host=host, port=port
-        )
-        return cls(connection, table_name)
+        if use_pool:
+            pool = await cls.create_pool(
+                user=user,
+                password=password,
+                database=db_name,
+                host=host,
+                port=port,
+                **pool_kwargs,
+            )
+            return cls(connection=None, pool=pool, table_name=table_name)
+        else:
+            # Original behavior - direct connection
+            connection = await asyncpg.connect(
+                user=user, password=password, database=db_name, host=host, port=port
+            )
+            return cls(connection=connection, table_name=table_name)
 
-    def __init__(self, connection, table_name: str = "burr_state", serde_kwargs: dict = None):
+    def __init__(
+        self,
+        connection=None,
+        pool=None,
+        table_name: str = "burr_state",
+        serde_kwargs: dict = None,
+    ):
         """Constructor
 
-        :param connection: the connection to the PostgreSQL database.
+        :param connection: the connection to the PostgreSQL database (optional if pool is provided)
+        :param pool: a connection pool to use instead of a direct connection (optional if connection is provided)
         :param table_name:  the table name to store things under.
+        :param serde_kwargs: kwargs for state serialization/deserialization
         """
+        if connection is None and pool is None:
+            raise ValueError("Either connection or pool must be provided")
+
         self.table_name = table_name
         self.connection = connection
+        self.pool = pool
         self.serde_kwargs = serde_kwargs or {}
         self._initialized = False
+
+    def copy(self) -> "Self":
+        """Creates a copy of this persister.
+
+        If using a pool, returns a new persister that will acquire its own connection from the pool.
+        If using a direct connection, raises an error as connections cannot be shared.
+        """
+        if self.pool is not None:
+            return AsyncPostgreSQLPersister(
+                connection=None,
+                pool=self.pool,
+                table_name=self.table_name,
+                serde_kwargs=self.serde_kwargs,
+            )
+        else:
+            return AsyncPostgreSQLPersister(
+                connection=self.connection,
+                table_name=self.table_name,
+                serde_kwargs=self.serde_kwargs,
+            )
 
     async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.connection.close()
+        await self.cleanup()
         return False
+
+    async def _get_connection(self):
+        """Gets a connection - either the dedicated one or one from the pool."""
+        if self.pool is not None:
+            return await self.pool.acquire(), True
+        elif self.connection is not None:
+            return self.connection, False
+        else:
+            raise ValueError("No connection or pool available")
+
+    async def _release_connection(self, connection, acquired):
+        """Releases a connection back to the pool if it was acquired."""
+        if acquired and self.pool is not None:
+            await self.pool.release(connection)
 
     def set_serde_kwargs(self, serde_kwargs: dict):
         """Sets the serde_kwargs for the persister."""
@@ -106,25 +193,29 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
 
     async def create_table(self, table_name: str):
         """Helper function to create the table where things are stored."""
-        async with self.connection.transaction():
-            await self.connection.execute(
-                f"""
-                CREATE TABLE IF NOT EXISTS {table_name} (
-                    partition_key TEXT DEFAULT '{self.PARTITION_KEY_DEFAULT}',
-                    app_id TEXT NOT NULL,
-                    sequence_id INTEGER NOT NULL,
-                    position TEXT NOT NULL,
-                    status TEXT NOT NULL,
-                    state JSONB NOT NULL,
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                    PRIMARY KEY (partition_key, app_id, sequence_id, position)
-                )"""
-            )
-            await self.connection.execute(
-                f"""
-                CREATE INDEX IF NOT EXISTS {table_name}_created_at_index ON {table_name} (created_at);
-            """
-            )
+        conn, acquired = await self._get_connection()
+        try:
+            async with conn.transaction():
+                await conn.execute(
+                    f"""
+                    CREATE TABLE IF NOT EXISTS {table_name} (
+                        partition_key TEXT DEFAULT '{self.PARTITION_KEY_DEFAULT}',
+                        app_id TEXT NOT NULL,
+                        sequence_id INTEGER NOT NULL,
+                        position TEXT NOT NULL,
+                        status TEXT NOT NULL,
+                        state JSONB NOT NULL,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                        PRIMARY KEY (partition_key, app_id, sequence_id, position)
+                    )"""
+                )
+                await conn.execute(
+                    f"""
+                    CREATE INDEX IF NOT EXISTS {table_name}_created_at_index ON {table_name} (created_at);
+                """
+                )
+        finally:
+            await self._release_connection(conn, acquired)
 
     async def initialize(self):
         """Creates the table"""
@@ -139,23 +230,35 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
         if self._initialized:
             return True
 
-        query = "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $1)"
-        self._initialized = await self.connection.fetchval(query, self.table_name, column=0)
-        return self._initialized
+        conn, acquired = await self._get_connection()
+        try:
+            query = "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = $1)"
+            self._initialized = await conn.fetchval(query, self.table_name, column=0)
+            return self._initialized
+        finally:
+            await self._release_connection(conn, acquired)
 
     async def list_app_ids(self, partition_key: str, **kwargs) -> list[str]:
         """Lists the app_ids for a given partition_key."""
-        query = (
-            f"SELECT DISTINCT app_id, created_at FROM {self.table_name} "
-            "WHERE partition_key = $1 "
-            "ORDER BY created_at DESC"
-        )
-        fetched_data = await self.connection.fetch(query, partition_key)
-        app_ids = [row[0] for row in fetched_data]
-        return app_ids
+        conn, acquired = await self._get_connection()
+        try:
+            query = (
+                f"SELECT DISTINCT app_id, created_at FROM {self.table_name} "
+                "WHERE partition_key = $1 "
+                "ORDER BY created_at DESC"
+            )
+            fetched_data = await conn.fetch(query, partition_key)
+            app_ids = [row[0] for row in fetched_data]
+            return app_ids
+        finally:
+            await self._release_connection(conn, acquired)
 
     async def load(
-        self, partition_key: Optional[str], app_id: str, sequence_id: int = None, **kwargs
+        self,
+        partition_key: Optional[str],
+        app_id: str,
+        sequence_id: int = None,
+        **kwargs,
     ) -> Optional[persistence.PersistedStateData]:
         """Loads state for a given partition id.
 
@@ -171,47 +274,53 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
             partition_key = self.PARTITION_KEY_DEFAULT
         logger.debug("Loading %s, %s, %s", partition_key, app_id, sequence_id)
 
-        if app_id is None:
-            # get latest for all app_ids
-            query = (
-                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
-                "WHERE partition_key = $1 "
-                f"ORDER BY CREATED_AT DESC LIMIT 1"
-            )
-            row = await self.connection.fetchrow(query, partition_key)
+        conn, acquired = await self._get_connection()
+        try:
+            row = None
+            if app_id is None:
+                # get latest for all app_ids
+                query = (
+                    f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                    "WHERE partition_key = $1 "
+                    f"ORDER BY CREATED_AT DESC LIMIT 1"
+                )
+                row = await conn.fetchrow(query, partition_key)
+            elif sequence_id is None:
+                query = (
+                    f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                    "WHERE partition_key = $1 AND app_id = $2 "
+                    f"ORDER BY sequence_id DESC LIMIT 1"
+                )
+                row = await conn.fetchrow(query, partition_key, app_id)
+            else:
+                query = (
+                    f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
+                    "WHERE partition_key = $1 AND app_id = $2 AND sequence_id = $3 "
+                )
+                row = await conn.fetchrow(
+                    query,
+                    partition_key,
+                    app_id,
+                    sequence_id,
+                )
 
-        elif sequence_id is None:
-            query = (
-                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
-                "WHERE partition_key = $1 AND app_id = $2 "
-                f"ORDER BY sequence_id DESC LIMIT 1"
-            )
-            row = await self.connection.fetchrow(query, partition_key, app_id)
-        else:
-            query = (
-                f"SELECT position, state, sequence_id, app_id, created_at, status FROM {self.table_name} "
-                "WHERE partition_key = $1 AND app_id = $2 AND sequence_id = $3 "
-            )
-            row = await self.connection.fetchrow(
-                query,
-                partition_key,
-                app_id,
-                sequence_id,
-            )
-        if row is None:
-            return None
-        # converts from asyncpg str to dict
-        json_row = json.loads(row[1])
-        _state = state.State.deserialize(json_row, **self.serde_kwargs)
-        return {
-            "partition_key": partition_key,
-            "app_id": row[3],
-            "sequence_id": row[2],
-            "position": row[0],
-            "state": _state,
-            "created_at": row[4],
-            "status": row[5],
-        }
+            if row is None:
+                return None
+
+            # converts from asyncpg str to dict
+            json_row = json.loads(row[1])
+            _state = state.State.deserialize(json_row, **self.serde_kwargs)
+            return {
+                "partition_key": partition_key,
+                "app_id": row[3],
+                "sequence_id": row[2],
+                "position": row[0],
+                "state": _state,
+                "created_at": row[4],
+                "status": row[5],
+            }
+        finally:
+            await self._release_connection(conn, acquired)
 
     async def save(
         self,
@@ -250,15 +359,21 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister):
             status,
         )
 
-        json_state = json.dumps(state.serialize(**self.serde_kwargs))
-        query = (
-            f"INSERT INTO {self.table_name} (partition_key, app_id, sequence_id, position, state, status) "
-            "VALUES ($1, $2, $3, $4, $5, $6)"
-        )
-        await self.connection.execute(
-            query, partition_key, app_id, sequence_id, position, json_state, status
-        )
+        conn, acquired = await self._get_connection()
+        try:
+            json_state = json.dumps(state.serialize(**self.serde_kwargs))
+            query = (
+                f"INSERT INTO {self.table_name} (partition_key, app_id, sequence_id, position, state, status) "
+                "VALUES ($1, $2, $3, $4, $5, $6)"
+            )
+            await conn.execute(
+                query, partition_key, app_id, sequence_id, position, json_state, status
+            )
+        finally:
+            await self._release_connection(conn, acquired)
 
     async def cleanup(self):
         """Closes the connection to the database."""
-        await self.connection.close()
+        if self.connection is not None:
+            await self.connection.close()
+            self.connection = None

--- a/burr/integrations/persisters/b_asyncpg.py
+++ b/burr/integrations/persisters/b_asyncpg.py
@@ -155,7 +155,7 @@ class AsyncPostgreSQLPersister(persistence.AsyncBaseStatePersister, BaseCopyable
         """Creates a copy of this persister.
 
         If using a pool, returns a new persister that will acquire its own connection from the pool.
-        If using a direct connection, raises an error as connections cannot be shared.
+        If using a direct connection, just returns a new persister with the same connection (won't work for async parallelism)
         """
         if self.pool is not None:
             return AsyncPostgreSQLPersister(

--- a/docs/concepts/actions.rst
+++ b/docs/concepts/actions.rst
@@ -15,6 +15,22 @@ Actions do the heavy-lifting in a workflow. They should contain all complex comp
 either through a class-based or function-based API. If actions implement ``async def run`` then will be run in an
 asynchronous context (and thus require one of the async application functions).
 
+.. note::
+    When implementing asynchronous actions with ``async def run``, you must also override the ``is_async`` method
+    to return ``True``. This tells the framework to execute the action in an asynchronous context:
+
+    .. code-block:: python
+
+        class AsyncAction(Action):
+            @property
+            def is_async(self) -> bool:
+                return True
+
+            async def run(self, state: State) -> dict:
+                # Async implementation
+                ...
+
+
 Actions have two primary responsibilities:
 
 1. ``run`` -- compute a result

--- a/docs/concepts/sync-vs-async.rst
+++ b/docs/concepts/sync-vs-async.rst
@@ -21,6 +21,31 @@ Burr gives you the ability to write synchronous (standard python) and asynchrono
    * :py:meth:`.run() <.Application.run()>`
    * :py:meth:`.stream_result() <.Application.stream_result()>`
 
+Checklist for Async Applications
+-------------------------------
+
+When building asynchronous applications with Burr, ensure you:
+
+1. **Use async action implementations**:
+   * Implement ``async def run`` methods in your actions
+   * Override the ``is_async`` property to return ``True`` in all async class-based actions
+   * Use ``await`` for all I/O operations inside your actions
+
+2. **Use async builder and application methods**:
+   * Use ``.abuild()`` instead of ``.build()``
+   * Use ``.arun()``, ``.aiterate()``, and ``.astream_result()`` instead of their sync counterparts
+
+3. **Use async hooks and persisters**:
+   * Implement async hooks with ``async def`` methods
+   * Use async persisters (e.g., ``AsyncPGPersister`` instead of ``PGPersister``)
+   * Properly clean up async resources using context managers or explicit cleanup calls
+
+4. **For parallel actions**:
+   * Make ``actions``, ``states``, and ``reduce`` methods async
+   * Override ``is_async`` to return ``True``
+   * Use ``AsyncGenerator`` return types
+   * Use async persisters with connection pools
+
 Comparison
 ----------
 


### PR DESCRIPTION
This PR adds a way to instantiate the async postgres persister with a connection pool. The goal is to prevent a bug in parallelism: when the user implements async versions of map-reduce classes (i.e. set is_async to True), burr calls `asyncio.gather` instead of threads, meaning we can't reuse the connection of the async persister. 

One solution is to update `b_asyncpg` to use a connection pool instead of a single connection and add a copy method to it, meaning that when burr cascades to get persisters for each sub-app, we get a new connection from the pool each time. 

## Changes

- Added a way to instantiate `AsyncPostgresPersister` with a pool instead of a connection
- Added a copy method that favors using the pool in copied instances if self.pool is not None
- Kept everything backwards compatible
- Also added missing async related docs

## How I tested this

Manual testing

## Notes

So far I only implemented a proposed solution in `b_asyncpg`, but the issue is still present in other async persister implementations. Once we agree on a definitive solution, I can update them as well. 

Open question:

- Do we really want to keep things backwards compatible and let user instantiate with a simple connection? In most scenarios a pool is safer, especially in async context

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add connection pool support to `AsyncPostgreSQLPersister` for better parallelism handling in async contexts.
> 
>   - **Behavior**:
>     - `AsyncPostgreSQLPersister` can now be instantiated with a connection pool using `from_values()` with `use_pool=True`.
>     - Adds `copy()` method to `AsyncPostgreSQLPersister` to create new instances using the pool.
>     - Updates `_get_connection()` and `_release_connection()` to handle pooled connections.
>   - **Documentation**:
>     - Updates `actions.rst`, `parallelism.rst`, and `sync-vs-async.rst` to include information about using connection pools with async persisters.
>   - **Misc**:
>     - Maintains backward compatibility with direct connections.
>     - Fixes minor formatting issues in `b_asyncpg.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=DAGWorks-Inc%2Fburr&utm_source=github&utm_medium=referral)<sup> for c4d6293bb3c9dadbd9ea387fab6e5b1687167aaf. You can [customize](https://app.ellipsis.dev/DAGWorks-Inc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->