### PR TITLE
fix the order of 'context' and 'inputs' arguments in class MapActions' function signature of "actions" 

### DIFF
--- a/burr/core/parallelism.py
+++ b/burr/core/parallelism.py
@@ -598,7 +598,7 @@ class MapActions(MapActionsAndStates, abc.ABC):
 
         class TestMultipleModels(MapActions):
 
-            def actions(self, state: State, inputs: Dict[str, Any], context: ApplicationContext) -> Generator[Action | Callable | RunnableGraph, None, None]:
+            def actions(self, state: State, context: ApplicationContext, inputs: Dict[str, Any]) -> Generator[Action | Callable | RunnableGraph, None, None]:
                 # Make sure to add a name to the action if you use bind() with a function,
                 # note that these can be different actions, functions, etc...
                 # in this case we're using `.bind()` to create multiple actions, but we can use some mix of
@@ -631,7 +631,7 @@ class MapActions(MapActionsAndStates, abc.ABC):
 
     @abc.abstractmethod
     def actions(
-        self, state: State, inputs: Dict[str, Any], context: ApplicationContext
+        self, state: State, context: ApplicationContext, inputs: Dict[str, Any]
     ) -> SyncOrAsyncGenerator[SubgraphType]:
         """Gives all actions to map over, given the state/inputs.
 


### PR DESCRIPTION
The order of context and inputs was wrong.

## Changes

The actions function signature and the example in docstring

## How I tested this

## Notes

## Checklist

- [ ] PR has an informative and human-readable title (this will be pulled into the release notes)
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
