### PR TITLE
use notifications@burr.a.o mailing list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -54,7 +54,7 @@ github:
 
 notifications:
   commits:              commits@burr.apache.org
-  issues:               dev@hamilton.apache.org
-  pullrequests:         dev@hamilton.apache.org
-  discussions:          dev@hamilton.apache.org
-  jobs:                 dev@hamilton.apache.org
+  issues:               notifications@burr.apache.org
+  pullrequests:         notifications@burr.apache.org
+  discussions:          notifications@burr.apache.org
+  jobs:                 notifications@burr.apache.org


### PR DESCRIPTION
Fix incorrect mailing lists (Hamilton ones) and use new notifications mailing list to keep dev mailing list from being dominated by automated emails.
