### PR TITLE
[DOC] small typo fix in state-persistence.rst

### DIFF
--- a/docs/concepts/state-persistence.rst
+++ b/docs/concepts/state-persistence.rst
@@ -134,7 +134,7 @@ To make the above more concrete, let's look at a basic chatbot:
             state_persister,
             resume_at_next_action=True,
             default_state={"chat_history" : []},
-            default_entrypoint="human_converse
+            default_entrypoint="human_converse"
         )
         .with_state_persister(state_persister)
         .with_identifiers(app_id=app_id)


### PR DESCRIPTION
small typo fix in  state-persistence.rst


## Changes

`default_entrypoint="human_converse`  -> `default_entrypoint="human_converse"`


## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future TODOs are captured in comments
- [ ] Project documentation has been updated if adding/changing functionality.
