### PR TITLE
Add Google Sheets Persister (#213)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,4 @@ burr/tracking/server/build
 examples/*/statemachine
 examples/*/*/statemachine
 .vscode
+google_creds.json

--- a/burr/integrations/persisters/b_google_sheets.py
+++ b/burr/integrations/persisters/b_google_sheets.py
@@ -1,0 +1,29 @@
+import json
+from burr.core.persistence import BaseStatePersister
+
+
+class GoogleSheetsPersister(BaseStatePersister):
+    """
+    Persister that stores Burr state in Google Sheets.
+    """
+
+    def __init__(self, spreadsheet_id):
+        self.spreadsheet_id = spreadsheet_id
+
+    def save(self, app_id: str, partition_key: str, state: dict):
+        """
+        Save state to Google Sheets
+        """
+        print("Saving state to Google Sheets")
+
+    def load(self, app_id: str, partition_key: str):
+        """
+        Load state from Google Sheets
+        """
+        print("Loading state from Google Sheets")
+
+    def list(self, app_id: str):
+        """
+        List partitions
+        """
+        return []

--- a/burr/integrations/persisters/b_google_sheets.py
+++ b/burr/integrations/persisters/b_google_sheets.py
@@ -1,29 +1,78 @@
 import json
-from burr.core.persistence import BaseStatePersister
+from burr.core import persistence
+from googleapiclient.discovery import build
+from google.oauth2.service_account import Credentials
 
-
-class GoogleSheetsPersister(BaseStatePersister):
+class GoogleSheetsPersister(persistence.BaseStatePersister):
     """
     Persister that stores Burr state in Google Sheets.
     """
 
-    def __init__(self, spreadsheet_id):
+    def __init__(self, spreadsheet_id: str, credentials_file: str):
         self.spreadsheet_id = spreadsheet_id
+        scopes = ["https://www.googleapis.com/auth/spreadsheets"]
+        creds = Credentials.from_service_account_file(
+        credentials_file,
+        scopes=scopes)
+        self.service = build("sheets", "v4", credentials=creds)
 
+    
+    
     def save(self, app_id: str, partition_key: str, state: dict):
-        """
-        Save state to Google Sheets
-        """
-        print("Saving state to Google Sheets")
+        state_json = json.dumps(state)
+
+        values = [[app_id, partition_key, state_json]]
+        body = {"values": values}
+
+        self.service.spreadsheets().values().append(
+            spreadsheetId=self.spreadsheet_id,
+            range="states!A:C",
+            valueInputOption="RAW",
+            body=body).execute()
+        
+
 
     def load(self, app_id: str, partition_key: str):
-        """
-        Load state from Google Sheets
-        """
-        print("Loading state from Google Sheets")
+        result = self.service.spreadsheets().values().get(
+        spreadsheetId=self.spreadsheet_id,
+        range="states!A:C").execute()
+
+        rows = result.get("values", [])
+
+        for row in rows:
+            if len(row) >= 3 and row[0] == app_id and row[1] == partition_key:
+                return json.loads(row[2])
+
+        return None
+    
+
 
     def list(self, app_id: str):
-        """
-        List partitions
-        """
-        return []
+        result = self.service.spreadsheets().values().get(
+        spreadsheetId=self.spreadsheet_id,
+        range="states!A:C").execute()
+
+        rows = result.get("values", [])
+        partition_keys = []
+
+        for row in rows:
+            if len(row) >= 2 and row[0] == app_id:
+                partition_keys.append(row[1])
+
+        return partition_keys
+    
+
+
+    def list_app_ids(self):
+        result = self.service.spreadsheets().values().get(
+        spreadsheetId=self.spreadsheet_id,
+        range="states!A:C").execute()
+
+        rows = result.get("values", [])
+        app_ids = []
+
+        for row in rows[1:]:
+            if len(row) >= 1 and row[0] not in app_ids:
+                app_ids.append(row[0])
+
+        return app_ids

--- a/test_sheets.py
+++ b/test_sheets.py
@@ -1,0 +1,15 @@
+from burr.integrations.persisters.b_google_sheets import GoogleSheetsPersister
+
+persister = GoogleSheetsPersister(
+    spreadsheet_id="1ur4GqM0tQQyCRn3lAj5bZk3DAeZBvrbYRwKok780hHc",
+    credentials_file="google_creds.json"
+)
+
+# Save some data
+persister.save("demo_app", "user1", {"hello": "world"})
+
+# Load the data
+data = persister.load("demo_app", "user1")
+
+print("Loaded data:", data)
+print("App IDs:", persister.list_app_ids())


### PR DESCRIPTION
Initial skeleton implementation for a GoogleSheetsPersister.

This follows the structure of existing Burr persisters and introduces a new persister that will store Burr state in Google Sheets using the Google Sheets Python API.

Planned next steps:
- Implement save/load logic
- Add example usage
- Add tests