### PR TITLE
fix(pydantic): allow union of BaseModel types as stream_type

### DIFF
--- a/burr/core/action.py
+++ b/burr/core/action.py
@@ -1511,14 +1511,15 @@ class streaming_action:
         writes: List[str],
         state_input_type: Type["BaseModel"],
         state_output_type: Type["BaseModel"],
-        stream_type: Union[Type["BaseModel"], Type[dict]],
+        stream_type: Union[Type["BaseModel"], Type[dict], object],
         tags: Optional[List[str]] = None,
     ) -> Callable:
         """Creates a streaming action that uses pydantic models.
 
         :param reads: The fields this consumes from the state.
         :param writes: The fields this writes to the state.
-        :param stream_type: The pydantic model or dictionary type that is used to represent the partial results.
+        :param stream_type: The pydantic model, dictionary type, or a union of pydantic models
+            (e.g. ``ModelA | ModelB``) used to represent the partial results.
             Use a dict if you want this untyped.
         :param state_input_type: The pydantic model type that is used to represent the input state.
         :param state_output_type: The pydantic model type that is used to represent the output state.

--- a/burr/integrations/pydantic.py
+++ b/burr/integrations/pydantic.py
@@ -269,7 +269,7 @@ def pydantic_action(
     return decorator
 
 
-PartialType = Union[Type[pydantic.BaseModel], Type[dict]]
+PartialType = Union[Type[pydantic.BaseModel], Type[dict], object]
 
 PydanticStreamingActionFunctionSync = Callable[
     ..., Generator[Tuple[Union[pydantic.BaseModel, dict], Optional[pydantic.BaseModel]], None, None]
@@ -290,7 +290,7 @@ PydanticStreamingActionFunctionVar = TypeVar(
 
 def _validate_and_extract_signature_types_streaming(
     fn: PydanticStreamingActionFunction,
-    stream_type: Optional[Union[Type[pydantic.BaseModel], Type[dict]]],
+    stream_type: Optional[Union[Type[pydantic.BaseModel], Type[dict], object]],
     state_input_type: Optional[Type[pydantic.BaseModel]] = None,
     state_output_type: Optional[Type[pydantic.BaseModel]] = None,
 ) -> Tuple[


### PR DESCRIPTION
Fixes #607

## What

Broadens the `stream_type` parameter type annotation in `streaming_action.pydantic()` and `pydantic_streaming_action()` to accept a union of pydantic `BaseModel` types in addition to a single `Type[BaseModel]` or `Type[dict]`.

## Why

Users who pass a union of models (e.g. `MyModel1 | MyModel2`) hit a static type error at the call site because the parameter was typed as `Union[Type[BaseModel], Type[dict]]`, which only accepts a single concrete model type. The runtime validation logic in `_validate_and_extract_signature_types_streaming()` already handles union types correctly — this was a type annotation gap only.

## Changes

- `burr/core/action.py`: `stream_type` parameter in `streaming_action.pydantic()` widened to accept `object` (covers union types, which are not expressible as `Type[X]`).
- `burr/integrations/pydantic.py`: Same change to `PartialType` alias and the validator function signature.
- Docstring updated to mention union support.

## Testing

No behaviour change — this is a type annotation fix only. Existing tests continue to pass. Users can now write:

```python
union = MyModel1 | MyModel2

@streaming_action.pydantic(
    reads=[...],
    writes=[...],
    state_input_type=...,
    state_output_type=...,
    stream_type=union,
)
```

without a type error.