### PR TITLE
fix(tracking): replace deprecated datetime.utcnow() in S3 time partition

### DIFF
--- a/burr/tracking/s3client.py
+++ b/burr/tracking/s3client.py
@@ -204,7 +204,7 @@ class S3TrackingClient(SyncTrackingClient):
         self.stream_state: Dict[StateKey, StreamState] = dict()
 
     def _get_time_partition(self):
-        time = datetime.datetime.utcnow().isoformat()
+        time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
         return [time[:4], time[5:7], time[8:10], time[11:13], time[14:]]
 
     def get_prefix(self):


### PR DESCRIPTION
### What

`S3TrackingClient._get_time_partition()` in `burr/tracking/s3client.py` builds the S3 path partition using `datetime.datetime.utcnow()`:

```python
def _get_time_partition(self):
    time = datetime.datetime.utcnow().isoformat()
    return [time[:4], time[5:7], time[8:10], time[11:13], time[14:]]
```

### Why it matters

`datetime.utcnow()` is deprecated as of Python 3.12 (emits `DeprecationWarning`) and returns a **naive** datetime, which is a common source of timezone bugs.

### Fix

```python
time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
```

This is timezone-aware at the source (correct UTC) and then drops tzinfo so that `.isoformat()` produces a **byte-identical** string to the old call:

```
old utcnow().isoformat():                          '2026-05-20T18:53:24.500598'
now(utc).replace(tzinfo=None).isoformat():         '2026-05-20T18:53:24.500674'
```

Using `now(utc).isoformat()` directly would have appended `+00:00` and broken the `time[14:]` slice, so `.replace(tzinfo=None)` is intentional to preserve the existing partition format exactly.

### Verification

Confirmed the two formats are identical in shape (no offset suffix), so the resulting S3 prefixes (`year/month/day/hour/...`) are unchanged. File parses and imports. Happy to adjust if you would prefer keeping the offset or a different partition scheme.