### PR TITLE
fix: add explicit encoding="utf-8" to text-mode file I/O

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -477,14 +477,14 @@ def create_test_case(
     if target_file_name:
         # if it already exists, load it up and append to it
         if os.path.exists(target_file_name):
-            with open(target_file_name, "r") as f:
+            with open(target_file_name, "r", encoding="utf-8") as f:
                 # assumes it's a list of test cases
                 current_testcases = json.load(f)
             current_testcases.append(tc_json)
         else:
             current_testcases = [tc_json]
         print(f"\nWriting data to file {target_file_name}")
-        with open(target_file_name, "w") as f:
+        with open(target_file_name, "w", encoding="utf-8") as f:
             json.dump(current_testcases, f, indent=2)
     else:
         logger.info(json.dumps(tc_json, indent=2))

--- a/burr/integrations/streamlit.py
+++ b/burr/integrations/streamlit.py
@@ -95,7 +95,7 @@ def load_state_from_log_file(jsonl_log_file: str, app: Application) -> AppState:
     :return: AppState
     """
     out = []
-    for i, line in enumerate(open(jsonl_log_file)):
+    for i, line in enumerate(open(jsonl_log_file, encoding="utf-8")):
         json_line = json.loads(line)
         record = Record(
             state=json_line["state"],

--- a/burr/testing/__init__.py
+++ b/burr/testing/__init__.py
@@ -26,7 +26,7 @@ import json
 # and then load it for the test.
 def load_test_cases(file_name: str) -> tuple:
     """Load test cases from a json file."""
-    with open(file_name, "r") as f:
+    with open(file_name, "r", encoding="utf-8") as f:
         json_test_cases = json.load(f)
         test_cases = [(tc.get("input_state"), tc.get("expected_state")) for tc in json_test_cases]
         test_ids = [

--- a/burr/tracking/server/run.py
+++ b/burr/tracking/server/run.py
@@ -375,7 +375,7 @@ def create_burr_ui_app(serve_static: bool = SERVE_STATIC) -> FastAPI:
         ui_app.mount("/public", StaticFiles(directory=base_asset_directory, html=True), "/public")
 
         # Read index.html once at startup
-        with open(os.path.join(base_asset_directory, "index.html")) as f:
+        with open(os.path.join(base_asset_directory, "index.html"), encoding="utf-8") as f:
             _index_html_template = f.read()
 
         @ui_app.get("/manifest.json")


### PR DESCRIPTION
### What

Several text-mode `open()` calls in `burr/` do not specify an encoding, so they fall back to the platform default (`locale.getpreferredencoding()`), which is **cp1252** on Windows rather than UTF-8:

| File | Purpose |
|------|---------|
| `burr/cli/__main__.py` | read + write JSON test-case files |
| `burr/testing/__init__.py` | read JSON test cases |
| `burr/integrations/streamlit.py` | read JSONL tracking log |
| `burr/tracking/server/run.py` | read bundled `index.html` at startup |

### Why it matters

JSON and JSONL are defined as UTF-8 (RFC 8259). On a non-UTF-8 platform, any non-ASCII content in tracked state, test cases, or the UI bundle would raise `UnicodeDecodeError` or be silently corrupted, even though the files are valid UTF-8.

### Fix

Added `encoding="utf-8"` to each affected text-mode `open()` call. No behavior change on systems that already default to UTF-8, since UTF-8 is a strict superset of ASCII.

### Verification

All four files still parse and import. The existing append-mode log handle in `tracking/client.py` already sets `encoding="utf-8"`, so this aligns the rest of the file I/O with that convention. Happy to adjust scope if you would prefer these split up.