### PR TITLE
fix: use timezone-aware S3 partition timestamps

### DIFF
--- a/burr/tracking/s3client.py
+++ b/burr/tracking/s3client.py
@@ -204,7 +204,7 @@ class S3TrackingClient(SyncTrackingClient):
         self.stream_state: Dict[StateKey, StreamState] = dict()
 
     def _get_time_partition(self):
-        time = datetime.datetime.utcnow().isoformat()
+        time = datetime.datetime.now(datetime.timezone.utc).isoformat()
         return [time[:4], time[5:7], time[8:10], time[11:13], time[14:]]
 
     def get_prefix(self):


### PR DESCRIPTION
## Summary
- replace deprecated `datetime.utcnow()` in the S3 tracking client partition timestamp
- use `datetime.now(datetime.timezone.utc)` so generated partition timestamps are timezone-aware

## Before / after
Before, `S3TrackingClient.save()` generated a naive UTC timestamp with `datetime.datetime.utcnow().isoformat()`.
After, it generates an explicit UTC timestamp such as `2026-05-24T03:12:34+00:00`.

## Verification
- `python -m py_compile burr/tracking/s3client.py`
- `git diff --check`
