### PR TITLE
fix: use utf-8 for test case json files

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -477,14 +477,14 @@ def create_test_case(
     if target_file_name:
         # if it already exists, load it up and append to it
         if os.path.exists(target_file_name):
-            with open(target_file_name, "r") as f:
+            with open(target_file_name, "r", encoding="utf-8") as f:
                 # assumes it's a list of test cases
                 current_testcases = json.load(f)
             current_testcases.append(tc_json)
         else:
             current_testcases = [tc_json]
         print(f"\nWriting data to file {target_file_name}")
-        with open(target_file_name, "w") as f:
+        with open(target_file_name, "w", encoding="utf-8") as f:
             json.dump(current_testcases, f, indent=2)
     else:
         logger.info(json.dumps(tc_json, indent=2))

--- a/burr/testing/__init__.py
+++ b/burr/testing/__init__.py
@@ -26,7 +26,7 @@ import json
 # and then load it for the test.
 def load_test_cases(file_name: str) -> tuple:
     """Load test cases from a json file."""
-    with open(file_name, "r") as f:
+    with open(file_name, "r", encoding="utf-8") as f:
         json_test_cases = json.load(f)
         test_cases = [(tc.get("input_state"), tc.get("expected_state")) for tc in json_test_cases]
         test_ids = [


### PR DESCRIPTION
## Summary
- read and write generated test-case JSON files with explicit UTF-8 encoding
- read dynamic pytest test-case JSON fixtures with the same encoding

## Before / after
Before, the CLI test-case generator and `load_test_cases()` relied on the platform default text encoding for JSON fixture files.
After, both paths use UTF-8 explicitly, making generated fixtures portable across non-UTF-8 locales.

## Verification
- `python -m py_compile burr/cli/__main__.py burr/testing/__init__.py`
- `git diff --check`
