### PR TITLE
fix(cli): bound server readiness polling

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -49,6 +49,8 @@ except ImportError as e:
 # Clear default handlers
 setup_logging(logging.INFO)
 
+SERVER_READY_TIMEOUT_SECONDS = 1
+
 
 def _command(command: str, capture_output: bool, addl_env: dict | None = None) -> str:
     """Runs a simple command"""
@@ -100,7 +102,7 @@ def _locate_package_root() -> Optional[str]:
 def open_when_ready(check_url: str, open_url: str):
     while True:
         try:
-            response = requests.get(check_url)
+            response = requests.get(check_url, timeout=SERVER_READY_TIMEOUT_SECONDS)
             if response.status_code == 200:
                 webbrowser.open(open_url)
                 return

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,25 @@
+from unittest.mock import Mock
+
+import requests
+
+from burr.cli import __main__ as cli_main
+
+
+def test_open_when_ready_uses_timeout_and_retries(monkeypatch):
+    ready_response = Mock(status_code=200)
+    get = Mock(side_effect=[requests.exceptions.Timeout, ready_response])
+    sleep = Mock()
+    open_browser = Mock()
+
+    monkeypatch.setattr(cli_main.requests, "get", get)
+    monkeypatch.setattr(cli_main.time, "sleep", sleep)
+    monkeypatch.setattr(cli_main.webbrowser, "open", open_browser)
+
+    cli_main.open_when_ready("http://localhost:7241", "http://localhost:7241/app")
+
+    assert get.call_count == 2
+    get.assert_called_with(
+        "http://localhost:7241", timeout=cli_main.SERVER_READY_TIMEOUT_SECONDS
+    )
+    sleep.assert_called_once_with(1)
+    open_browser.assert_called_once_with("http://localhost:7241/app")


### PR DESCRIPTION
## Problem

`open_when_ready()` polls the local server readiness URL before opening the browser, but the `requests.get()` call has no timeout. If the readiness endpoint accepts a connection and then stalls, the polling thread can block indefinitely instead of retrying.

## Before / After

Before, a stalled readiness request could hang inside `requests.get()`.

After, the readiness poll uses a small named timeout and keeps the existing retry behavior for request exceptions.

## Verification

- `python -m pytest tests/cli/test_main.py`