### PR TITLE
docs: fix multiple typos and broken code examples (#725)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ burr
 ```
 
 This will open up Burr's telemetry UI. It comes loaded with some default data so you can click around.
-It also has a demo chat application to help demonstrate what the UI captures enabling you too see things changing in
+It also has a demo chat application to help demonstrate what the UI captures enabling you to see things changing in
 real-time. Hit the "Demos" side bar on the left and select `chatbot`. To chat it requires the `OPENAI_API_KEY`
 environment variable to be set, but you can still see how it works if you don't have an API key set.
 
@@ -94,7 +94,7 @@ def ai_response(state: State) -> State:
     # query the LLM however you want (or don't use an LLM, up to you...)
     response = _query_llm(state["chat_history"]) # Burr doesn't care how you use LLMs!
     chat_item = {"role" : "system", "content" : response}
-    return state.update(response=content).append(chat_history=chat_item)
+    return state.update(response=response).append(chat_history=chat_item)
 
 app = (
     ApplicationBuilder()
@@ -113,7 +113,7 @@ print("answer:", app.state["response"])
 Apache Burr includes:
 
 1. A (dependency-free) low-abstraction python library that enables you to build and manage state machines with simple python functions
-2. A UI you can use view execution telemetry for introspection and debugging
+2. A UI you can use to view execution telemetry for introspection and debugging
 3. A set of integrations to make it easier to persist state, connect to telemetry, and integrate with other systems
 
 ![Burr at work](https://github.com/apache/burr/blob/main/chatbot.gif)

--- a/docs/concepts/actions.rst
+++ b/docs/concepts/actions.rst
@@ -26,7 +26,7 @@ Actions
 .. note::
 
     Actions are the core building block of Burr. They read from state and write to state.
-    They can be synchronous and asynchonous, and have both a ``sync`` and ``async`` API.
+    They can be synchronous and asynchronous, and have both a ``sync`` and ``async`` API.
     There are both function and class-based APIs.
 
 
@@ -96,7 +96,7 @@ above is equivalent to returning an empty dictionary instead of the results.
     from burr.core import action, State
 
     @action(reads=["var_from_state"], writes=["var_to_update"])
-    def custom_action(state: State) -> State
+    def custom_action(state: State) -> State:
         return results, state.update(var_to_update=var_from_state + 1)
 
     app = ApplicationBuilder().with_actions(

--- a/docs/concepts/state-persistence.rst
+++ b/docs/concepts/state-persistence.rst
@@ -271,7 +271,7 @@ tracked runs. This is useful for debugging, or building an application that enab
             tracker,
             resume_at_next_action=True,
             default_state={"chat_history" : []},
-            default_entrypoint="human_converse
+            default_entrypoint="human_converse"
         )
         .with_tracker(tracker)
         .with_identifiers(app_id=app_id)

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -33,7 +33,7 @@ along with a fully built server.
 This will give you tools to visualize, track, and interact with the UI. You can explore the UI (including some sample projects)
 simply by running the command ``burr``. Up next we'll write our own application and follow it in the UI.
 
-If you're using poetry, you can't install the ``start`` target directly, due to [this issue](https://github.com/python-poetry/poetry/issues/3369).
+If you're using poetry, you can't install the ``start`` target directly, due to `this issue <https://github.com/python-poetry/poetry/issues/3369>`_.
 Instead, please install manually using the following command:
 
 .. code-block:: bash

--- a/docs/getting_started/simple-example.rst
+++ b/docs/getting_started/simple-example.rst
@@ -222,4 +222,4 @@ Now that we've built a basic application, we can do the following with only a fe
 2. :ref:`Persist state to a database + reload <state-persistence>` -- add a ``initialize_from`` line to the builder and select a pre-existing/implement a custom persistence method.
 3. :ref:`Add monitoring to track application data <tracking>` -- leverage ``with_tracker`` to track to the Burr UI and visualize your application live.
 4. :ref:`Stream results back <streaming>` -- minimize time to first token by streaming results back to the user.
-5. `Generate test cases from prior runs <https://github.com/apache/burr/tree/main/examples/test-case-creation>`_ -- use the ``burr-testburr-test-case create`` command to automatically generate test cases for your LLM app.
+5. `Generate test cases from prior runs <https://github.com/apache/burr/tree/main/examples/test-case-creation>`_ -- use the ``burr-test-case create`` command to automatically generate test cases for your LLM app.

--- a/docs/getting_started/up-next.rst
+++ b/docs/getting_started/up-next.rst
@@ -88,7 +88,7 @@ Once you're comfortable with the UI, you may want to get a sense of a few of the
 of the Burr library and where you can go to learn more about them:
 
 - :ref:`Creating custom actions <actions>` and calling out to integrated frameworks
-- :ref:`Running applications <applications>`, managing their lifeycyle, and inspecting the results
+- :ref:`Running applications <applications>`, managing their lifecycle, and inspecting the results
 - :ref:`Managing state <state>` -- persisting, inspecting, and updating
 - :ref:`Handling transition between nodes <transitions>` and managing the flow of your application
 - :ref:`Adding hooks to customize execution <hooks>` and integrate with other systems


### PR DESCRIPTION
## What this PR does / why we need it
This PR fixes several documentation issues identified in #725:
- Multiple typos in README.md and RST files
- Fixed broken code example in README.md (response=content to response=response)
- Fixed garbled command name in simple-example.rst
- Fixed markdown link syntax to RST in install.rst
- Fixed missing colon in function signature in actions.rst
- Fixed missing closing quote in state-persistence.rst

## Special notes for your reviewers
- All changes are documentation-only (no code changes)
- Each fix addresses a specific issue mentioned in #725
- Changes follow existing documentation style and formatting

Closes #725