### PR TITLE
test: cover SQLitePersister construction, lifecycle, and load variants

### DIFF
--- a/tests/core/test_persistence.py
+++ b/tests/core/test_persistence.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import pickle
+import sqlite3
+
 import pytest
 
 from burr.core import State
@@ -127,6 +130,97 @@ def test_sqlite_persister_list_app_ids_without_initialize_raises_runtime_error()
     try:
         with pytest.raises(RuntimeError, match="Uninitialized persister"):
             persister.list_app_ids("partition_key")
+    finally:
+        persister.cleanup()
+
+
+def test_sqlite_persister_from_values(tmp_path):
+    persister = SQLLitePersister.from_values(
+        db_path=str(tmp_path / "test.db"), table_name="test_table"
+    )
+    try:
+        persister.initialize()
+        persister.save("pk", "app_id", 1, "position", State({"key": "value"}), "completed")
+        loaded = persister.load("pk", "app_id")
+        assert loaded["state"] == State({"key": "value"})
+    finally:
+        persister.cleanup()
+
+
+def test_sqlite_persister_from_config(tmp_path):
+    persister = SQLLitePersister.from_config(
+        {"db_path": str(tmp_path / "test.db"), "table_name": "test_table"}
+    )
+    try:
+        persister.initialize()
+        assert persister.is_initialized()
+        assert persister.table_name == "test_table"
+    finally:
+        persister.cleanup()
+
+
+def test_sqlite_persister_context_manager_closes_connection(tmp_path):
+    with SQLLitePersister(db_path=str(tmp_path / "test.db"), table_name="test_table") as persister:
+        persister.initialize()
+    with pytest.raises(sqlite3.ProgrammingError):
+        persister.connection.cursor()
+
+
+def test_sqlite_persister_copy_creates_independent_connection(tmp_path):
+    persister = SQLLitePersister(db_path=str(tmp_path / "test.db"), table_name="test_table")
+    persister.initialize()
+    persister.save("pk", "app_id", 1, "position", State({"key": "value"}), "completed")
+    copied = persister.copy()
+    try:
+        assert copied.connection is not persister.connection
+        assert copied.db_path == persister.db_path
+        assert copied.table_name == persister.table_name
+        loaded = copied.load("pk", "app_id")
+        assert loaded["state"] == State({"key": "value"})
+    finally:
+        persister.cleanup()
+        copied.cleanup()
+
+
+def test_sqlite_persister_pickle_roundtrip_reconnects(tmp_path):
+    persister = SQLLitePersister(db_path=str(tmp_path / "test.db"), table_name="test_table")
+    persister.initialize()
+    persister.save("pk", "app_id", 1, "position", State({"key": "value"}), "completed")
+    unpickled = pickle.loads(pickle.dumps(persister))
+    try:
+        loaded = unpickled.load("pk", "app_id")
+        assert loaded["state"] == State({"key": "value"})
+    finally:
+        persister.cleanup()
+        unpickled.cleanup()
+
+
+def test_sqlite_persister_load_latest_when_app_id_is_none():
+    persister = SQLLitePersister(db_path=":memory:", table_name="test_table")
+    try:
+        persister.initialize()
+        persister.save("pk", "app_id1", 1, "position", State({"key": "value1"}), "completed")
+        persister.save("pk", "app_id2", 1, "position", State({"key": "value2"}), "completed")
+        loaded = persister.load("pk", None)
+        assert loaded is not None
+        assert loaded["app_id"] in ("app_id1", "app_id2")
+        expected_value = "value1" if loaded["app_id"] == "app_id1" else "value2"
+        assert loaded["state"] == State({"key": expected_value})
+    finally:
+        persister.cleanup()
+
+
+def test_sqlite_persister_load_specific_sequence_id():
+    persister = SQLLitePersister(db_path=":memory:", table_name="test_table")
+    try:
+        persister.initialize()
+        persister.save("pk", "app_id", 1, "first", State({"key": "value1"}), "completed")
+        persister.save("pk", "app_id", 2, "second", State({"key": "value2"}), "completed")
+        loaded = persister.load("pk", "app_id", sequence_id=1)
+        assert loaded["sequence_id"] == 1
+        assert loaded["position"] == "first"
+        assert loaded["state"] == State({"key": "value1"})
+        assert persister.load("pk", "app_id", sequence_id=99) is None
     finally:
         persister.cleanup()
 


### PR DESCRIPTION
## Summary
Coverage analysis showed several public `SQLitePersister` paths had no tests: `from_values`, `from_config`, `copy()`, the context-manager protocol, pickling (`__getstate__`/`__setstate__`, which the parallelism machinery relies on to ship persisters across processes), and the `load()` branches for `app_id=None` (latest across apps) and explicit `sequence_id`. This adds focused unit tests for each; no behavior changes.

## Changes made
- `tests/core/test_persistence.py`: 7 new tests covering constructor classmethods, context-manager connection closing, `copy()` connection independence, pickle round-trip reconnection, and the remaining `load()` query branches (including a missing `sequence_id` returning `None`).

## How to test
```bash
pytest tests/core/test_persistence.py
```

## Notes
The `app_id=None` test asserts shape rather than which app wins: `created_at` has second resolution in SQLite, so latest-across-apps ordering is non-deterministic for rapid successive writes (asserting a specific winner would be flaky).

## Checklist
- [x] Tests added or updated
- [x] All tests pass locally (`pytest tests/ --ignore=tests/integration_tests`: 580 passed, 5 skipped)
- [x] Commits signed off (`git commit -s`)
- [x] Pre-commit hooks pass (black, isort, flake8)
- [x] CONTRIBUTING.md guidelines followed