### PR TITLE
build: advertise LICENSE in sdist metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ maintainers = [
 ]
 description = "Apache Burr (incubating) makes it easy to develop applications that make decisions (chatbots, agents, simulations, etc...) from simple python building blocks."
 readme = "README.md"
-license-files = ["LICENSE-wheel", "NOTICE", "DISCLAIMER"]
+license-files = ["LICENSE", "LICENSE-wheel", "NOTICE", "DISCLAIMER"]
 keywords = ["mlops", "data", "state-machine", "llmops"]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/tests/test_release_config.py
+++ b/tests/test_release_config.py
@@ -152,3 +152,17 @@ def test_examples_include_exclude_coverage():
         errors.append(summary)
 
     assert not errors, "\n".join(errors)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="tomllib requires Python 3.11+")
+def test_license_files_include_combined_project_license():
+    """Ensure package metadata advertises the combined project license file."""
+    project_root = Path(__file__).parent.parent
+    pyproject_path = project_root / "pyproject.toml"
+
+    with open(pyproject_path, "rb") as f:
+        config = tomllib.load(f)
+
+    license_files = config.get("project", {}).get("license-files", [])
+
+    assert license_files == ["LICENSE", "LICENSE-wheel", "NOTICE", "DISCLAIMER"]


### PR DESCRIPTION
Closes #755.

## Summary

The sdist already ships the combined `LICENSE` file, but `project.license-files` only advertised `LICENSE-wheel`, `NOTICE`, and `DISCLAIMER`. That meant the generated `PKG-INFO` `License-File` metadata under-reported the combined Apache 2.0 + bundled MIT attribution file used for the website UI components.

This change adds `LICENSE` to `project.license-files` and adds a regression test to keep that metadata list from drifting.

## Changes

- add `LICENSE` to `project.license-files` in `pyproject.toml`
- add a focused release-config test that asserts the expected license-files list

## Validation

- `python3 -m py_compile tests/test_release_config.py`
- `XDG_CACHE_HOME=/tmp/xdg-cache UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_release_config.py -q`
  - result: `2 passed, 1 warning in 0.01s`
- `XDG_CACHE_HOME=/tmp/xdg-cache UV_CACHE_DIR=/tmp/uv-cache uv run python -m flit build --format sdist`
  - result: built `dist/apache_burr-0.42.0.tar.gz`
- `tar -xOf dist/apache_burr-0.42.0.tar.gz 'apache_burr-0.42.0/PKG-INFO' | rg '^License-File:'`\n  - result includes `DISCLAIMER`, `LICENSE`, `LICENSE-wheel`, and `NOTICE`\n\n## Notes\n\n- The pytest run emitted an existing `PytestConfigWarning` about unknown config option `asyncio_mode`; it did not affect the test result.