### PR TITLE
fix(core): wipe() with no arguments should clear all state instead of raising

### DIFF
--- a/burr/core/state.py
+++ b/burr/core/state.py
@@ -436,8 +436,10 @@ class State(Mapping, Generic[StateType]):
             )
         if delete is not None:
             fields_to_delete = delete
-        else:
+        elif keep is not None:
             fields_to_delete = [key for key in self._state if key not in keep]
+        else:
+            fields_to_delete = list(self._state)
         return self.apply_operation(DeleteField(fields_to_delete))
 
     def merge(self, other: "State") -> "State[StateType]":

--- a/tests/core/test_state.py
+++ b/tests/core/test_state.py
@@ -121,6 +121,13 @@ def test_state_wipe_keep():
     assert wiped.get_all() == {"foo": "bar"}
 
 
+def test_state_wipe_all():
+    # wipe() with neither delete nor keep should clear everything, as documented.
+    state = State({"foo": "bar", "baz": "qux"})
+    wiped = state.wipe()
+    assert wiped.get_all() == {}
+
+
 def test_state_append_validate_failure():
     state = State({"foo": "bar"})
     with pytest.raises(ValueError, match="non-appendable"):


### PR DESCRIPTION
## What

`State.wipe()` with no arguments should clear all state, but currently raises `TypeError`.

The docstring says:

> If you pass nothing in it will delete the whole thing.

But when both `delete` and `keep` are `None`, the method fell through to the `keep` branch and evaluated `key not in keep` with `keep=None`:

```python
>>> from burr.core.state import State
>>> State({"a": 1, "b": 2}).wipe()
TypeError: argument of type 'NoneType' is not a container or iterable
```

The `delete=` and `keep=` forms were covered by tests, but the documented no-args form was not, so this went unnoticed.

## Fix

Handle the three cases explicitly in `wipe()`:

- `delete=[...]` -> delete those keys
- `keep=[...]` -> delete everything not kept
- neither -> delete every key (matches the docstring)

## Verification

```python
State({"a": 1, "b": 2}).wipe()            # {}
State({"a": 1, "b": 2}).wipe(keep=["a"])   # {"a": 1}
State({"a": 1, "b": 2}).wipe(delete=["a"]) # {"b": 2}
```

Added `test_state_wipe_all` alongside the existing wipe tests. `tests/core/test_state.py` passes (27 passed).