### PR TITLE
fix(ui): harden token costs refresh script

### DIFF
--- a/telemetry/ui/scripts/token_costs.py
+++ b/telemetry/ui/scripts/token_costs.py
@@ -21,7 +21,8 @@ url = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_c
 import requests
 import json
 
-response = requests.get(url)
+response = requests.get(url, timeout=30)
+response.raise_for_status()
 data = response.json()
 
 keys_wanted = ["input_cost_per_token", "output_cost_per_token", "max_tokens", "max_input_tokens", "max_output_tokens"]
@@ -34,5 +35,5 @@ for model_entry in data:
             del data[model_entry][key]
 
 # save the data
-with open("model_costs.json", "w") as f:
+with open("model_costs.json", "w", encoding="utf-8") as f:
     json.dump(data, f)


### PR DESCRIPTION
## Problem

The token-cost refresh script fetches LiteLLM's model pricing JSON and writes `model_costs.json`, but the network request can hang indefinitely and HTTP failures are not surfaced explicitly. The generated JSON write also relied on the platform default text encoding.

## Before / after

Before:
- `requests.get()` used no timeout.
- HTTP error responses were passed straight to JSON parsing.
- `model_costs.json` was written with the default platform encoding.

After:
- the request has a bounded timeout,
- HTTP failures raise through `raise_for_status()`, and
- the generated JSON is written as UTF-8.

## Verification

- `python -m py_compile telemetry/ui/scripts/token_costs.py`
- Ran `telemetry/ui/scripts/token_costs.py` from a temporary working directory and confirmed it generated `model_costs.json`
- `git diff --check`