### PR TITLE
fix(examples): bound image telephone downloads

### DIFF
--- a/examples/image-telephone/application.py
+++ b/examples/image-telephone/application.py
@@ -42,6 +42,8 @@ from burr.core import Action, ApplicationBuilder, State, default, expr
 from burr.core.action import action
 from burr.lifecycle import PostRunStepHook
 
+IMAGE_DOWNLOAD_TIMEOUT_SECONDS = 30
+
 # import hamilton modules that define the DAGs for image captioning and image generation
 caption_images = dataflows.import_module("caption_images", "elijahbenizzy")
 generate_images = dataflows.import_module("generate_images", "elijahbenizzy")
@@ -67,7 +69,11 @@ class ImageSaverHook(PostRunStepHook):
             image_url = state["current_image_location"]
             image_name = "image_" + str(state["__SEQUENCE_ID"]) + ".png"
             with open(os.path.join(self.path, image_name), "wb") as f:
-                f.write(requests.get(image_url).content)
+                response = requests.get(
+                    image_url, timeout=IMAGE_DOWNLOAD_TIMEOUT_SECONDS
+                )
+                response.raise_for_status()
+                f.write(response.content)
                 print(f"Saved image to {self.path}/{image_name}")
 
 

--- a/examples/integrations/hamilton/image-telephone/application.py
+++ b/examples/integrations/hamilton/image-telephone/application.py
@@ -33,6 +33,8 @@ from burr.core.action import action
 from burr.integrations import hamilton
 from burr.lifecycle import PostRunStepHook
 
+IMAGE_DOWNLOAD_TIMEOUT_SECONDS = 30
+
 caption_images = dataflows.import_module("caption_images", "elijahbenizzy")
 generate_images = dataflows.import_module("generate_images", "elijahbenizzy")
 
@@ -53,7 +55,11 @@ class ImageSaverHook(PostRunStepHook):
             image_url = state["current_image_location"]
             image_name = "image_" + str(state["__SEQUENCE_ID"]) + ".png"
             with open(os.path.join(self.path, image_name), "wb") as f:
-                f.write(requests.get(image_url).content)
+                response = requests.get(
+                    image_url, timeout=IMAGE_DOWNLOAD_TIMEOUT_SECONDS
+                )
+                response.raise_for_status()
+                f.write(response.content)
                 print(f"Saved image to {self.path}/{image_name}")
 
 


### PR DESCRIPTION
## Problem

The image-telephone examples download generated image URLs with `requests.get(image_url).content`. Without a timeout, the examples can hang indefinitely if the image host stalls. They also write the response body without checking HTTP status, so an error response can be saved as if it were an image.

## Before / after

Before, both the base image-telephone example and the Hamilton integration variant used unbounded image downloads and did not call `raise_for_status()`.

After, both examples use a 30 second image download timeout and call `raise_for_status()` before writing the image bytes. Successful downloads keep the same behavior.

## Verification

- `python -m py_compile examples\image-telephone\application.py examples\integrations\hamilton\image-telephone\application.py`
- `git diff --check`