### PR TITLE
feat(core): add dependency-free graph serialization

### DIFF
--- a/burr/core/application.py
+++ b/burr/core/application.py
@@ -606,6 +606,15 @@ class ApplicationGraph(Graph):
 
     entrypoint: Action
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-serializable application graph metadata.
+
+        :return: Graph metadata including the application's entrypoint.
+        """
+        graph_data = super().to_dict()
+        graph_data.update(type="application_graph", entrypoint=self.entrypoint.name)
+        return graph_data
+
 
 @dataclasses.dataclass
 class ApplicationIdentifiers:

--- a/burr/core/graph.py
+++ b/burr/core/graph.py
@@ -177,6 +177,37 @@ class Graph:
             )
         return self._action_tag_map.get(tag)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a dependency-free, JSON-serializable representation of the graph.
+
+        Actions and transitions retain their declaration order. Unordered action
+        metadata is sorted so repeated exports are deterministic.
+
+        :return: Graph metadata suitable for external tools and user interfaces.
+        """
+        actions = []
+        for action in self.actions:
+            required_inputs, optional_inputs = action.optional_and_required_inputs
+            actions.append(
+                {
+                    "name": action.name,
+                    "reads": sorted(action.reads),
+                    "writes": sorted(action.writes),
+                    "inputs": sorted(required_inputs),
+                    "optional_inputs": sorted(optional_inputs),
+                    "tags": sorted(action.tags),
+                }
+            )
+        transitions = [
+            {
+                "from": transition.from_.name,
+                "to": transition.to.name,
+                "condition": transition.condition.name,
+            }
+            for transition in self.transitions
+        ]
+        return {"type": "graph", "actions": actions, "transitions": transitions}
+
     def visualize(
         self,
         output_file_path: Optional[Union[str, pathlib.Path]] = None,

--- a/docs/reference/application.rst
+++ b/docs/reference/application.rst
@@ -51,6 +51,24 @@ of situations.
 
 The ``GraphBuilder`` class is used to build a graph, and the ``Graph`` class can be passed to the application builder.
 
+Graphs can also be exported without Graphviz or tracking dependencies. ``to_dict()``
+returns JSON-serializable action and transition metadata for external tools, API
+responses, and custom user interfaces:
+
+.. code-block:: python
+
+    import json
+
+    graph_data = application.graph.to_dict()
+    payload = json.dumps(graph_data)
+
+``ApplicationGraph.to_dict()`` additionally includes the application entrypoint and
+uses ``application_graph`` as its type. This compact metadata format intentionally
+omits action source code and is distinct from the tracking subsystem's persisted
+``ApplicationModel`` format. Action and transition declaration order is preserved,
+while set-like metadata such as reads, writes, inputs, and tags is sorted for
+deterministic output.
+
 .. autoclass:: burr.core.graph.GraphBuilder
    :members:
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -15,11 +15,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typing import Callable
+import json
+from typing import Callable, Union
 
 import pytest
 
 from burr.core import Action, Condition, Result, State, default
+from burr.core.application import ApplicationGraph
 from burr.core.graph import GraphBuilder, _validate_actions, _validate_transitions
 
 
@@ -31,7 +33,7 @@ class PassedInAction(Action):
         writes: list[str],
         fn: Callable[..., dict],
         update_fn: Callable[[dict, State], State],
-        inputs: list[str],
+        inputs: Union[list[str], tuple[list[str], list[str]]],
         tags: list[str] = None,
     ):
         super(PassedInAction, self).__init__()
@@ -204,3 +206,77 @@ def test_get_actions_by_tag():
     assert len(graph.get_actions_by_tag("tag3")) == 1
     with pytest.raises(ValueError, match="not found"):
         graph.get_actions_by_tag("tag4")
+
+
+def test_graph_to_dict_returns_dependency_free_structure():
+    export_action = PassedInAction(
+        reads=["z_read", "a_read"],
+        writes=["z_write", "a_write"],
+        fn=lambda state, **inputs: inputs,
+        update_fn=lambda result, state: state,
+        inputs=(["z_required", "a_required"], ["z_optional", "a_optional"]),
+        tags=["z_tag", "a_tag"],
+    )
+    graph = (
+        GraphBuilder()
+        .with_actions(zeta=export_action, alpha=Result("a_read"))
+        .with_transitions(
+            ("zeta", "alpha", Condition.expr("a_read < z_read")),
+            ("alpha", "zeta"),
+        )
+        .build()
+    )
+
+    exported = graph.to_dict()
+
+    assert exported == {
+        "type": "graph",
+        "actions": [
+            {
+                "name": "zeta",
+                "reads": ["a_read", "z_read"],
+                "writes": ["a_write", "z_write"],
+                "inputs": ["a_required", "z_required"],
+                "optional_inputs": ["a_optional", "z_optional"],
+                "tags": ["a_tag", "z_tag"],
+            },
+            {
+                "name": "alpha",
+                "reads": ["a_read"],
+                "writes": [],
+                "inputs": [],
+                "optional_inputs": [],
+                "tags": [],
+            },
+        ],
+        "transitions": [
+            {"from": "zeta", "to": "alpha", "condition": "a_read < z_read"},
+            {"from": "alpha", "to": "zeta", "condition": "default"},
+        ],
+    }
+    assert json.loads(json.dumps(exported)) == exported
+
+
+def test_application_graph_to_dict_includes_entrypoint():
+    counter = base_counter_action.with_name("counter")
+    graph = ApplicationGraph(
+        actions=[counter],
+        transitions=[],
+        entrypoint=counter,
+    )
+
+    assert graph.to_dict() == {
+        "type": "application_graph",
+        "entrypoint": "counter",
+        "actions": [
+            {
+                "name": "counter",
+                "reads": ["count"],
+                "writes": ["count"],
+                "inputs": [],
+                "optional_inputs": [],
+                "tags": ["tag1", "tag2"],
+            }
+        ],
+        "transitions": [],
+    }


### PR DESCRIPTION
Expose a compact graph representation that external tools can consume without installing Graphviz or Burr's tracking dependencies.

## Changes

- add `Graph.to_dict()` with action, input, tag, and transition metadata
- add `ApplicationGraph.to_dict()` with an explicit entrypoint and `application_graph` type
- preserve action and transition declaration order while sorting set-like metadata
- document that the compact export is distinct from the tracking `ApplicationModel` persistence format
- cover deterministic ordering, required and optional inputs, conditions, and JSON round trips

## How I tested this

- `pre-commit run --all-files`
- `python -m pytest tests --ignore=tests/integrations/persisters --ignore=tests/integrations/test_bip0042_bedrock.py -q` (`645 passed, 1 skipped`)
- `python -m sphinx -T -W --keep-going -b dirhtml -d <doctrees> -D language=en . <html>` from `docs/`

## Notes

This intentionally omits action source code. It is a dependency-free metadata export, not a replacement for the tracking subsystem's persisted graph schema.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.
