### PR TITLE
Fix the Graph API example on the applications concepts page

### DIFF
--- a/docs/concepts/state-machine.rst
+++ b/docs/concepts/state-machine.rst
@@ -171,7 +171,7 @@ in a web-server (create a graph once, application many times), import the graph 
 
 .. code-block:: python
 
-    from burr.core import ApplicationBuilder, default, expr
+    from burr.core import ApplicationBuilder, GraphBuilder
     graph = (
         GraphBuilder()
         .with_actions(human_input, ai_response)
@@ -183,7 +183,7 @@ in a web-server (create a graph once, application many times), import the graph 
     app = (
         ApplicationBuilder()
         .with_graph(graph)
-        with_state(chat_history=[])
+        .with_state(chat_history=[])
         .with_entrypoint("human_input")
         .build()
     )


### PR DESCRIPTION
The `Graph` / `Application` split example on the applications page cannot be copy-pasted: it raises a `SyntaxError` before it gets anywhere.

## Changes

Two lines in `docs/concepts/state-machine.rst`:

- `with_state(chat_history=[])` was missing its leading dot, so the builder chain broke mid-expression.
- The import read `from burr.core import ApplicationBuilder, default, expr`, which brings in two names the snippet never uses while leaving `GraphBuilder` undefined. Changed to `from burr.core import ApplicationBuilder, GraphBuilder`.

## How I tested this

Ran the corrected snippet with a `human_input` / `ai_response` action pair defined as in the surrounding docs. It builds the graph and the application without error. The original raises `SyntaxError` at the `with_state` line, and after fixing only that, `NameError: name 'GraphBuilder' is not defined`.

## Notes

Docs only, and deliberately separate from #893 so this one can go in on its own. Both branches touch `state-machine.rst` but not the same lines, so there is no conflict either way round.

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.

Made with [Cursor](https://cursor.com)