### PR TITLE
Bump to 0.43.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ Install from `pypi`:
 pip install "apache-burr[start]"
 ```
 
+> [!NOTE]
+> In version 0.43.0, the optional CLI included with `[start]`, `[learn]`, and
+> `[cli]` requires Python 3.10+. Core library usage remains compatible with
+> Python 3.9.
+
 (see [the docs](https://burr.apache.org/getting_started/install/) if you're using poetry)
 
 Then run the UI server:

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -33,6 +33,11 @@ along with a fully built server.
 This will give you tools to visualize, track, and interact with the UI. You can explore the UI (including some sample projects)
 simply by running the command ``burr``. Up next we'll write our own application and follow it in the UI.
 
+.. note::
+
+    In version 0.43.0, the optional CLI requires Python 3.10 or newer. The core Burr library remains compatible with
+    Python 3.9.
+
 If you're using poetry, you can't install the ``start`` target directly, due to
 `this issue <https://github.com/python-poetry/poetry/issues/3369>`_.
 Instead, please install manually using the following command:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "apache-burr"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [] # yes, there are none
 requires-python = ">=3.9"
 authors = [
@@ -31,6 +31,8 @@ authors = [
 maintainers = [
   {name = "Elijah ben Izzy", email = "elijah@apache.org"},
   {name = "Stefan Krawczyk", email = "stefan@apache.org"},
+  {name = "Jernej Frank", email = "jernejfrank@apache.org"},
+  {name = "André Ahlert", email = "andre@aex.partners"},
 ]
 description = "Apache Burr (incubating) makes it easy to develop applications that make decisions (chatbots, agents, simulations, etc...) from simple python building blocks."
 readme = "README.md"

--- a/website/src/app/downloads/page.tsx
+++ b/website/src/app/downloads/page.tsx
@@ -86,11 +86,12 @@ const ARTIFACT_TEMPLATES: ArtifactTemplate[] = [
 
 // To add a release, prepend an entry. The first entry is rendered as "Latest".
 const RELEASES: Release[] = [
+  { version: "0.43.0", date: "August 25, 2026" },
   { version: "0.42.0", date: "May 9, 2026" },
   {
     version: "0.41.0",
     date: "January 2026",
-    note: "The PyPI wheel for 0.41.0 had packaging issues. Build from the source release if you need this version, or just use 0.42.0.",
+    note: "The PyPI wheel for 0.41.0 had packaging issues. Build from the source release if you need this version, or just use the latest.",
   },
 ];
 

--- a/website/src/app/downloads/page.tsx
+++ b/website/src/app/downloads/page.tsx
@@ -86,7 +86,11 @@ const ARTIFACT_TEMPLATES: ArtifactTemplate[] = [
 
 // To add a release, prepend an entry. The first entry is rendered as "Latest".
 const RELEASES: Release[] = [
-  { version: "0.43.0", date: "August 25, 2026" },
+  {
+    version: "0.43.0",
+    date: "August 25, 2026",
+    note: "Known issue: the optional CLI functionality ([cli], [learn], and [start] extras) requires Python 3.10+. Core library usage remains compatible with Python 3.9.",
+  },
   { version: "0.42.0", date: "May 9, 2026" },
   {
     version: "0.41.0",
@@ -289,8 +293,10 @@ export default function DownloadsPage() {
               </pre>
 
               <p className="mt-4 text-xs text-[var(--muted)]">
-                Requires Python 3.10+. Burr has no required runtime
-                dependencies — extras are opt-in.
+                The core library supports Python 3.9+. In 0.43.0,
+                CLI-related extras require Python 3.10+ due to a known
+                compatibility issue. Burr has no required runtime dependencies
+                — extras are opt-in.
               </p>
             </div>
           </section>


### PR DESCRIPTION
The 0.43.0 has been released. This bumps on main and updates the website.

Release vote:
https://lists.apache.org/thread/w074myhfyykgss5gmcy5omw88cxolthg

Apache artifacts:
https://downloads.apache.org/incubator/burr/0.43.0/

PyPI:
https://pypi.org/project/apache-burr/0.43.0/"
