### PR TITLE
fix(integrations/hamilton): drop the stale extra argument to require_plugin

### DIFF
--- a/burr/integrations/hamilton.py
+++ b/burr/integrations/hamilton.py
@@ -25,7 +25,6 @@ try:
 except ImportError as e:
     require_plugin(
         e,
-        ["sf-hamilton"],
         "hamilton",
     )
 


### PR DESCRIPTION
## Problem

`burr.integrations.base.require_plugin` takes **two** parameters:

```python
def require_plugin(import_error: ImportError, plugin_name: str):
```

`burr/integrations/hamilton.py` passes **three**:

```python
try:
    from hamilton.driver import Driver
except ImportError as e:
    require_plugin(
        e,
        ["sf-hamilton"],   # <-- stale, from an older signature
        "hamilton",
    )
```

So importing `burr.integrations.hamilton` without `sf-hamilton` installed raises

```
TypeError: require_plugin() takes 2 positional arguments but 3 were given
```

instead of the actionable message the helper exists to produce. The failure hits
exactly the users the helper is meant to help — the ones who have not installed
the extra.

## Sibling baseline

Every one of the other **eleven** call sites passes `(e, "<extras-target>")`:

| File | Call |
|---|---|
| `burr/cli/__main__.py:44` | `require_plugin(e, "start")` |
| `burr/integrations/bedrock.py:65` | `require_plugin(e, "bedrock")` |
| `burr/integrations/langfuse.py:34` | `require_plugin(e, "langfuse")` |
| `burr/integrations/opentelemetry.py:40` | `require_plugin(e, "opentelemetry")` |
| `burr/integrations/streamlit.py:34` | `require_plugin(e, "streamlit")` |
| `burr/integrations/persisters/b_asyncpg.py:30` | `base.require_plugin(e, "asyncpg")` |
| `burr/integrations/persisters/b_psycopg2.py:23` | `base.require_plugin(e, "postgresql")` |
| `burr/integrations/persisters/b_redis.py:25` | `base.require_plugin(e, "redis")` |
| `burr/integrations/persisters/postgresql.py:26` | `base.require_plugin(e, "postgresql")` |
| `burr/tracking/client.py:92` | `require_plugin(e, "tracking-client")` |
| `burr/tracking/common/models.py:30` | `require_plugin(e, "tracking")` |
| `burr/tracking/s3client.py:58` | `require_plugin(e, "tracking-s3")` |

`hamilton.py` is the only one out of step. `"hamilton"` is already the correct
value: `pyproject.toml` defines `hamilton = ["sf-hamilton"]` as an extras target,
so the message resolves to `burr[hamilton]`, which is a real install command.

## Fix

Drop the stale `["sf-hamilton"]` argument — one line.

## Verification

Executing the real `burr/integrations/base.py` and replaying both call shapes:

```
=== current hamilton.py call: require_plugin(e, ["sf-hamilton"], "hamilton") ===
  TypeError: require_plugin() takes 2 positional arguments but 3 were given

=== sibling baseline, e.g. langfuse.py: require_plugin(e, "langfuse") ===
  ImportError: Missing plugin langfuse! To use the langfuse plugin, you must
  install the 'extras' target [langfuse] with burr[langfuse] ...

=== after this patch: require_plugin(e, "hamilton") ===
  ImportError: Missing plugin hamilton! To use the hamilton plugin, you must
  install the 'extras' target [hamilton] with burr[hamilton] ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
