### PR TITLE
fix(cli): bound readiness poll requests

### DIFF
--- a/burr/cli/__main__.py
+++ b/burr/cli/__main__.py
@@ -48,6 +48,7 @@ except ImportError as e:
 
 # Clear default handlers
 setup_logging(logging.INFO)
+OPEN_WHEN_READY_TIMEOUT_SECONDS = 5
 
 
 def _command(command: str, capture_output: bool, addl_env: dict | None = None) -> str:
@@ -100,7 +101,7 @@ def _locate_package_root() -> Optional[str]:
 def open_when_ready(check_url: str, open_url: str):
     while True:
         try:
-            response = requests.get(check_url)
+            response = requests.get(check_url, timeout=OPEN_WHEN_READY_TIMEOUT_SECONDS)
             if response.status_code == 200:
                 webbrowser.open(open_url)
                 return

--- a/tests/test_cli_open_when_ready.py
+++ b/tests/test_cli_open_when_ready.py
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from burr.cli import __main__ as cli_main
+
+
+def test_open_when_ready_bounds_readiness_request(monkeypatch):
+    calls = []
+
+    class Response:
+        status_code = 200
+
+    def fake_get(url, **kwargs):
+        calls.append((url, kwargs))
+        return Response()
+
+    opened = []
+    monkeypatch.setattr(cli_main.requests, "get", fake_get)
+    monkeypatch.setattr(cli_main.webbrowser, "open", opened.append)
+
+    cli_main.open_when_ready("http://localhost:7241/health", "http://localhost:7241")
+
+    assert calls == [
+        (
+            "http://localhost:7241/health",
+            {"timeout": cli_main.OPEN_WHEN_READY_TIMEOUT_SECONDS},
+        )
+    ]
+    assert opened == ["http://localhost:7241"]


### PR DESCRIPTION
## Summary
- add a timeout to the CLI readiness poll used before opening the local UI
- cover `open_when_ready()` so the readiness request stays bounded

## Tests
- `python -m pytest tests/test_cli_open_when_ready.py -q`
- `python -m py_compile burr/cli/__main__.py tests/test_cli_open_when_ready.py`
- `git diff --check`
