### PR TITLE
build: drop support for Python 3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7
@@ -80,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7
@@ -156,7 +156,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -180,8 +180,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 3.9 is skipped because burr/cli/__main__.py uses PEP 604 union syntax
-        # (dict | None) which requires Python 3.10+. Tracked separately.
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ pip install "apache-burr[start]"
 ```
 
 > [!NOTE]
-> In version 0.43.0, the optional CLI included with `[start]`, `[learn]`, and
-> `[cli]` requires Python 3.10+. Core library usage remains compatible with
-> Python 3.9.
+> Burr requires Python 3.10+. (Since 0.43.0, the optional CLI included with
+> `[start]`, `[learn]`, and `[cli]` already required Python 3.10+; as of the
+> next release, Python 3.9 is no longer supported anywhere.)
 
 (see [the docs](https://burr.apache.org/getting_started/install/) if you're using poetry)
 

--- a/docs/contributing/setup.rst
+++ b/docs/contributing/setup.rst
@@ -63,7 +63,7 @@ The latter command will automatically create and install virtual env if one does
 automatically install the project in editable mode with all developer dependencies defined in dev
 dependency group.
 
-This will install all potential dependencies. Burr will work with ``python >=3.9``.
+This will install all potential dependencies. Burr will work with ``python >=3.10``.
 
 ------------------
 Linting/Pre-Commit

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -35,8 +35,8 @@ simply by running the command ``burr``. Up next we'll write our own application 
 
 .. note::
 
-    In version 0.43.0, the optional CLI requires Python 3.10 or newer. The core Burr library remains compatible with
-    Python 3.9.
+    Burr requires Python 3.10 or newer. (Since 0.43.0, the optional CLI already required Python 3.10 or newer; as of
+    the next release, Python 3.9 is no longer supported.)
 
 If you're using poetry, you can't install the ``start`` target directly, due to
 `this issue <https://github.com/python-poetry/poetry/issues/3369>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ build-backend = "flit_core.buildapi"
 name = "apache-burr"
 version = "0.43.0"
 dependencies = [] # yes, there are none
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [
   {name = "Elijah ben Izzy", email = "elijah@apache.org"},
   {name = "Stefan Krawczyk", email = "stefan@apache.org"},

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,7 +52,7 @@ Specifically, we set the following guidelines:
 
 
 Prerequisites:
-- Python 3.9+
+- Python 3.10+
 - `flit` for building (`pip install flit`)
 - `twine` for package validation (`pip install twine`)
 - GPG key configured for signing

--- a/scripts/apache_release.py
+++ b/scripts/apache_release.py
@@ -717,7 +717,7 @@ def _build_sdist_from_git(version: str, output_dir: str = "dist") -> str:
         unpack_options: dict[str, Any] = {}
         if sys.version_info >= (3, 12):
             # This archive was just produced from our own Git repository. Be
-            # explicit on newer Python versions while retaining Python 3.9-3.11
+            # explicit on newer Python versions while retaining Python 3.10-3.11
             # compatibility, where shutil has no filter argument.
             unpack_options["filter"] = "fully_trusted"
         shutil.unpack_archive(str(source_archive), str(source_tree), format="tar", **unpack_options)

--- a/website/src/app/downloads/page.tsx
+++ b/website/src/app/downloads/page.tsx
@@ -293,9 +293,9 @@ export default function DownloadsPage() {
               </pre>
 
               <p className="mt-4 text-xs text-[var(--muted)]">
-                The core library supports Python 3.9+. In 0.43.0,
-                CLI-related extras require Python 3.10+ due to a known
-                compatibility issue. Burr has no required runtime dependencies
+                Burr requires Python 3.10+. (In 0.43.0,
+                CLI-related extras already required Python 3.10+ due to a known
+                compatibility issue; Python 3.9 is no longer supported.) Burr has no required runtime dependencies
                 — extras are opt-in.
               </p>
             </div>


### PR DESCRIPTION
## Changes

Python 3.9 is EOL, and the 0.43.0 RC1 release vote surfaced that the `[cli]`/`[learn]`/`[start]` extras were already broken on it (PEP 604 unions in `burr/cli/__main__.py`), forcing the release-validation smoke matrix to skip 3.9. This makes the 3.10 floor official everywhere:

- `pyproject.toml`: `requires-python = ">=3.10"` (no version-specific classifiers existed, so nothing else to drop there)
- CI: remove `3.9` from the four Python version matrices in `.github/workflows/python-package.yml`, and remove the now-obsolete 3.9 skip comment in `.github/workflows/release-validation.yml`
- docs: README note, `docs/getting_started/install.rst`, `docs/contributing/setup.rst`, and the website downloads page now state the 3.10+ requirement (the old "core remains compatible with 3.9" notes added by #902 are superseded)
- `scripts/README.md` prerequisite and the shutil-filter compatibility comment in `scripts/apache_release.py` (3.9-3.11 → 3.10-3.11)

No runtime behavior changes — metadata, CI, and documentation only.

Fixes #900

## How I tested this

- `uv sync` and `uv build` succeed with the new `requires-python` — sdist and wheel metadata build cleanly
- Both touched workflow files parse as valid YAML
- `pytest tests/core/test_action.py tests/core/test_application.py tests/test_release_config.py`: 235 passed / 61 failed — identical failure set on unmodified `main` under the same local interpreter (Python 3.14, above the supported ceiling), so the failures are pre-existing environment effects, not regressions
- `grep -rn "3\.9"` across toml/yml/rst/md/py confirms no remaining reference to 3.9 as a supported target (the remaining matches are either the historical 0.43.0 release note or `langfuse>=3.9` package-version comparisons, both intentionally untouched)

## Notes

- I deliberately did not touch the `py<3.9` AST comments in `burr/core/action.py` — they predate this change (they are already below the old 3.9 floor) and are harmless permissive parsing
- #901 (sdist/wheel naming and license cleanup) intentionally left out — it overlaps `scripts/apache_release.py`/`pyproject.toml` with the open #882; happy to pick it up after that lands

## Checklist

- [x] PR has an informative and human-readable title (this will be pulled into the release notes)
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed the pre-commit check & code is left cleaner/nicer than when first encountered.
- [ ] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future TODOs are captured in comments
- [x] Project documentation has been updated if adding/changing functionality.