### PR TITLE
fix: harden token cost refresh script

### DIFF
--- a/telemetry/ui/scripts/token_costs.py
+++ b/telemetry/ui/scripts/token_costs.py
@@ -21,7 +21,8 @@ url = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_c
 import requests
 import json
 
-response = requests.get(url)
+response = requests.get(url, timeout=30)
+response.raise_for_status()
 data = response.json()
 
 keys_wanted = ["input_cost_per_token", "output_cost_per_token", "max_tokens", "max_input_tokens", "max_output_tokens"]
@@ -34,5 +35,5 @@ for model_entry in data:
             del data[model_entry][key]
 
 # save the data
-with open("model_costs.json", "w") as f:
+with open("model_costs.json", "w", encoding="utf-8") as f:
     json.dump(data, f)


### PR DESCRIPTION
## Problem

`telemetry/ui/scripts/token_costs.py` refreshes pricing metadata from LiteLLM using an unbounded `requests.get()` call. If the remote endpoint stalls, the script can hang indefinitely. It also writes the generated JSON without an explicit text encoding, which makes the output depend on the platform default encoding.

## Before / after

Before:
- remote fetches had no timeout
- HTTP error responses were passed to `response.json()`
- `model_costs.json` was written with the process default text encoding

After:
- the fetch is bounded with a 30 second timeout
- HTTP failures are surfaced via `raise_for_status()` before parsing JSON
- the generated JSON is written with `encoding="utf-8"`

## Verification

- `python -m py_compile telemetry/ui/scripts/token_costs.py`
- `git diff --check`
- Ran the script from a temp working directory and confirmed it generated `model_costs.json`