### PR TITLE
fix: use utf-8 for redirect pyproject generation

### DIFF
--- a/burr-redirect/generate_pyproject.py
+++ b/burr-redirect/generate_pyproject.py
@@ -82,7 +82,7 @@ def render_extras(extras: list, version: str) -> str:
 
 def render_template(extras: list, version: str) -> str:
     """Substitute the extras section and the version into the template text."""
-    template = TEMPLATE.read_text()
+    template = TEMPLATE.read_text(encoding="utf-8")
     matches = [line for line in template.splitlines() if PLACEHOLDER in line]
     if not matches:
         fail(
@@ -135,7 +135,7 @@ def main(argv: list) -> None:
 
     version = argv[1]
     extras = read_root_extras()
-    OUTPUT.write_text(render_template(extras, version))
+    OUTPUT.write_text(render_template(extras, version), encoding="utf-8")
     verify(extras, version)
     print(f"Wrote {OUTPUT} for version {version} with {len(extras)} extras.")
 


### PR DESCRIPTION
## Problem
`burr-redirect/generate_pyproject.py` reads the template and writes the generated redirect package `pyproject.toml` without specifying a text encoding. On systems where the preferred locale is not UTF-8, that can make this release helper dependent on the local default encoding.

## Before / after
Before, `Path.read_text()` and `Path.write_text()` used the platform default encoding.

After, both template read and generated TOML write explicitly use UTF-8, matching the expected encoding for project metadata files.

## Verification
- `python -m py_compile burr-redirect\generate_pyproject.py`
- `python burr-redirect\generate_pyproject.py 0.43.0`
- Confirmed the generated `burr-redirect/pyproject.toml` did not change.